### PR TITLE
Wip research time tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ If there is a researcher for whom, if given sufficient time for her belief to co
 
 When the network is a de facto complete network, scientists might be able to utilize a more performant sharing procedure (the second condition is that they have to be converged): `share-fast`. This variable signals whether or not such a de-facto complete network is present in the current run.  
 
+#### g-exit-condition?
+
+* format: boolean
+* example: false  
+
+If the `exit-condition` reporter is evaluated the variable will be set to `true` in case the the exit-condition is met, `false` otherwise. Positive evaluation of the exit-condition marks the end of a run.  
+
 
 ### Turtles-own
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,20 @@ When the network is a de facto complete network, scientists might be able to uti
 
 If the `exit-condition` reporter is evaluated the variable will be set to `true` in case the the exit-condition is met, `false` otherwise. Positive evaluation of the exit-condition marks the end of a run.  
 
+#### g-myscientists
+
+* format: list
+* example: [3 7]  
+
+Reflects how many scientist are currently researching each theory: the first entry in the list is for theory one the 2nd entry for theory two.  
+  
+#### g-research-time
+
+* format: list
+* example: [350 129]  
+
+Records how much each theory has been researched over the course of the run: each round each researcher who pulls from the slot machine for a given theory increases the counter for this theory by one. The first entry in the list is for theory one the 2nd entry for theory two.  
+
 
 ### Turtles-own
 

--- a/SocNetABM.nlogo
+++ b/SocNetABM.nlogo
@@ -67,17 +67,38 @@ end
 
 
 
+; advances the model one round with- or without evaluating the exit-condition
+; depending on the argument:
+; exit? = exit-condition evaluated?, type: boolean
+to go [exit?]
+  let fast-sharing? 0
+  with-local-randomness [
+    set fast-sharing? (g-fast-sharing-enabled and converged-light)
+    if exit? and not g-exit-condition? [
+      set g-exit-condition? exit-condition
+    ]
+  ]
+  ifelse g-exit-condition? and exit? [
+    stop
+  ][
+    go-core fast-sharing?
+  ]
+end
+
+
+
+
+
 ; one go = one round
-to go-core
+to go-core [fast-sharing?]
   ask turtles [
     pull
   ]
-  let fast-sharing (g-fast-sharing-enabled and converged-light)
-  if fast-sharing [
+  if fast-sharing? [
     share-fast
   ]
   ask turtles [
-    if not fast-sharing [
+    if not fast-sharing? [
       share
     ]
     calc-posterior
@@ -98,25 +119,6 @@ to go-core
     act-on-strategies
   ]
   tick
-end
-
-
-
-
-; advances the model one round with- or without evaluating the exit-condition
-; depending on the argument:
-; exit? = exit-condition evaluated?, type: boolean
-to go [exit?]
-  with-local-randomness [
-    if exit? and not g-exit-condition? [
-      set g-exit-condition? exit-condition
-    ]
-  ]
-  ifelse g-exit-condition? and exit? [
-    stop
-  ][
-    go-core
-  ]
 end
 
 

--- a/SocNetABM.nlogo
+++ b/SocNetABM.nlogo
@@ -162,7 +162,7 @@ end
 to init-converge-reporters
   set converge-reporters (list [ -> average-belief 0 true]
   [ -> average-cum-successes 0 true] [ -> average-confidence true]
-  [ -> average-signal 0 true])
+  [ -> average-signal 0 true] [ -> research-time 0 true])
 end
 
 
@@ -891,6 +891,21 @@ When the network is a de facto complete network, scientists might be able to uti
 
 If the `exit-condition` reporter is evaluated the variable will be set to `true` in case the the exit-condition is met, `false` otherwise. Positive evaluation of the exit-condition marks the end of a run.  
 
+#### g-myscientists
+
+* format: list
+* example: [3 7]  
+
+Reflects how many scientist are currently researching each theory: the first entry in the list is for theory one the 2nd entry for theory two.  
+  
+#### g-research-time
+
+* format: list
+* example: [350 129]  
+
+Records how much each theory has been researched over the course of the run: each round each researcher who pulls from the slot machine for a given theory increases the counter for this theory by one. The first entry in the list is for theory one the 2nd entry for theory two.  
+
+
 ### Turtles-own
 
 #### cur-best-th
@@ -1335,6 +1350,8 @@ NetLogo 6.0.4
     <metric>frequency-converged "th2"</metric>
     <metric>center-of-convergence "th1"</metric>
     <metric>center-of-convergence "th2"</metric>
+    <metric>research-time "th1" false</metric>
+    <metric>research-time "th2" false</metric>
     <steppedValueSet variable="scientists" first="3" step="1" last="11"/>
     <enumeratedValueSet variable="th1-signal">
       <value value="0.5"/>

--- a/SocNetABM.nlogo
+++ b/SocNetABM.nlogo
@@ -7,7 +7,8 @@ globals [th-i-signal indiff-count crit-interactions-th1 crit-interactions-th2
   converge-reporters converge-reporters-values
   run-start-scientists-save rndseed g-confidence g-depressed-confidence
   g-fast-sharing-enabled g-last-convlight-th g-conv-dur-th1 g-conv-dur-th2
-  g-conv-start-th1 g-conv-start-th2 g-exit-condition?]
+  g-conv-start-th1 g-conv-start-th2 g-exit-condition? g-myscientists
+  g-research-time]
 
 __includes ["protocol.nls"]
 
@@ -53,6 +54,7 @@ to setup [rs]
   let th-1-scientist count turtles with [mytheory = 0]
   let th-2-scientist count turtles with [mytheory = 1]
   set run-start-scientists-save (list th-1-scientist th-2-scientist)
+  set g-myscientists run-start-scientists-save
   set g-depressed-confidence false
   set g-last-convlight-th -1
   set g-conv-dur-th1 []
@@ -60,6 +62,7 @@ to setup [rs]
   set g-conv-start-th1 []
   set g-conv-start-th2 []
   set g-exit-condition? false
+  set g-research-time [0 0]
   reset-ticks
 end
 
@@ -117,6 +120,9 @@ to go-core [fast-sharing?]
   ask turtles with [crit-interact-lock = 0
     and not member? mytheory cur-best-th] [
     act-on-strategies
+  ]
+  with-local-randomness [
+    compute-popularity
   ]
   tick
 end
@@ -619,8 +625,8 @@ true
 false
 "" ""
 PENS
-"best theory" 1.0 0 -2674135 true "" "plot count turtles with [mytheory = 0]"
-"not-best-theory" 1.0 0 -14835848 true "" "plot count turtles with [mytheory = 1]"
+"best theory" 1.0 0 -2674135 true "" "plot item 0 g-myscientists"
+"not-best-theory" 1.0 0 -14835848 true "" "plot item 1 g-myscientists"
 
 SWITCH
 16

--- a/protocol.nls
+++ b/protocol.nls
@@ -329,7 +329,7 @@ end
 ; reports the average signal for th# at the time of final convergence
 ; arguments:
 ; - th# = theory, type: string
-; - rec = recording?, type: boolean
+; - rec? = recording?, type: boolean
 to-report average-signal [th# rec?]
   let identifier "avgsignal"
   ifelse rec? [
@@ -362,7 +362,7 @@ end
 ; reports the average beliefs among the researchers
 ; arguments:
 ; - th# = theory, type: string
-; - rec = recording?, type: boolean
+; - rec? = recording?, type: boolean
 to-report average-belief [th# rec?]
   let identifier "avgbelief"
   ifelse rec? [

--- a/protocol.nls
+++ b/protocol.nls
@@ -529,3 +529,14 @@ to-report center-of-convergence [th#]
     2 * curstart * curlength + curlength ^ 2] convergence-starts conv-durations)
   report weighted-convergences / (2 * cur-cum-conv-dur)
 end
+
+
+
+
+
+to compute-popularity
+  set g-research-time (map + g-research-time g-myscientists)
+  let th-1-scientist count turtles with [mytheory = 0]
+  let th-2-scientist scientists - th-1-scientist
+  set g-myscientists (list th-1-scientist th-2-scientist)
+end

--- a/protocol.nls
+++ b/protocol.nls
@@ -540,3 +540,24 @@ to compute-popularity
   let th-2-scientist scientists - th-1-scientist
   set g-myscientists (list th-1-scientist th-2-scientist)
 end
+
+
+
+
+
+; reports the time scientists spent researching each theory before they finally 
+; converged
+; arguments:
+; - th# = theory, type: string
+; - rec? = recording?, type: boolean
+to-report research-time [th# rec?]
+  let identifier "restime"
+  ifelse rec? [
+    report (fput identifier g-research-time)
+  ][
+    set th# translate-from-string th#
+    let res-time but-first first filter [curitem -> 
+      first curitem = identifier] converge-reporters-values
+    report item th# res-time
+  ]
+end


### PR DESCRIPTION
This PR implements the tracking of research time similar to what we call in ArgABM `research-time-monist`. This allows us to see how much time scientists spent researching each theory over the course of a run. To accomplish this it adds a new reporter which records at the time scientists converge for the final time how much time they have spent on each theory during the run.
This PR supersedes #15 